### PR TITLE
Fix debug config reading

### DIFF
--- a/sono-importer.py
+++ b/sono-importer.py
@@ -18,7 +18,7 @@ config_devices = configparser.ConfigParser()
 config_devices.read(base_dir / 'devices.conf')
 
 #set config variables
-debug = bool(config['Main']['debug'])
+debug = config.getboolean('Main', 'debug')
 device = config['Main']['device']
 
 font = ImageFont.truetype(base_dir / config_devices[device]['font'], int(config_devices[device]['font_size']))


### PR DESCRIPTION
## Summary
- load debug setting with `ConfigParser.getboolean`

## Testing
- `python -m py_compile sono-importer.py`

------
https://chatgpt.com/codex/tasks/task_e_685f0071aa688327b27446bef9151eaa