### PR TITLE
Fix boolean debug parsing

### DIFF
--- a/sono-importer.py
+++ b/sono-importer.py
@@ -18,7 +18,10 @@ config_devices = configparser.ConfigParser()
 config_devices.read(base_dir / 'devices.conf')
 
 #set config variables
-debug = bool(config['Main']['debug'])
+# Properly parse boolean option. Using bool() on a string would always
+# evaluate to ``True`` for any non-empty value, so ``debug = "False"`` in
+# the configuration file had no effect.
+debug = config['Main'].getboolean('debug')
 device = config['Main']['device']
 
 font = ImageFont.truetype(base_dir / config_devices[device]['font'], int(config_devices[device]['font_size']))


### PR DESCRIPTION
## Summary
- fix debug flag parsing in `sono-importer.py`

## Testing
- `python -m py_compile sono-importer.py`

------
https://chatgpt.com/codex/tasks/task_e_685eff5466a88327a13a09bb56a4c8e7